### PR TITLE
Fixed engine restart logic, and make it work with set-config

### DIFF
--- a/libs/config_engine.py
+++ b/libs/config_engine.py
@@ -46,6 +46,14 @@ class ConfigEngine:
                     print("exception on %s!" % option)
                     self.section_options_dict[section][option] = None
 
+    def reload(self):
+        self.lock.acquire()
+        try:
+            self._load()
+        finally:
+            self.lock.release()
+
+
     def save(self, path):
         self.lock.acquire()
         try:
@@ -56,10 +64,22 @@ class ConfigEngine:
             self.lock.release()
 
     def get_section_dict(self, section):
-        return self.section_options_dict[section]
+        section_dict = None
+        self.lock.acquire()
+        try:
+           section_dict = self.section_options_dict[section]
+        finally:
+            self.lock.release()
+        return section_dict
 
     def get_sections(self):
-        return self.config.sections()
+        self.lock.acquire()
+        sections = None
+        try:
+            sections = self.config.sections()
+        finally:
+            self.lock.release()
+        return sections 
 
     def get_boolean(self, section, option):
         result = None
@@ -76,6 +96,7 @@ class ConfigEngine:
             self.config.set(section, option, str(not val))
         finally:
             self.lock.release()
+        self.save(self.config_file_path)
 
     def set_option_in_section(self, section, option, value):
         self.lock.acquire()

--- a/libs/processor_core.py
+++ b/libs/processor_core.py
@@ -54,7 +54,7 @@ class ProcessorCore:
                 
                 # TODO: Be sure you have done proper action before this so all threads are stopped
                 self._tasks = {}
-
+                self.config.reload()
                 self._engine = CvEngine(self.config)
                 logger.info("engine restarted")
                 self._result_queue.put(True)


### PR DESCRIPTION
Now if you post some configuration like:
`curl -d '{"App": { "VideoPath" : "/repo/data/gard1-4.mp4"} }' -H "Content-Type: application/json" -X POST http://localhost:8001/set-config`
it works well (I don't know why I had to add reload to the api's set-config too, it was not working without it). You can then check with get-config or request process-video-cfg and restart the UI to see your processor processing the new engine without any hassle :)